### PR TITLE
Fix bug w/ Clojure implementation

### DIFF
--- a/languages/Clojure/lib/deromanize/src/deromanize/core.clj
+++ b/languages/Clojure/lib/deromanize/src/deromanize/core.clj
@@ -26,4 +26,4 @@
   "Take STDIN roman numerals and convert them to a decimal value"
   [& args]
   (doseq [line (line-seq (java.io.BufferedReader. *in*))]
-    (println (apply digitize (str/split line #"")))))
+    (println (apply digitize (rest (str/split line #""))))))


### PR DESCRIPTION
The str/split call was leaving an empty string at the beginning of the list. A call to 'rest' gets rid of it.

``` clojure
> (clojure.string/split "XIV" #"")
["" "X" "I" "V"]
> (rest (clojure.string/split "XIV" #""))
("X" "I" "V")
```

I suspect you could just use `seq` instead of `split` w/ empty regex, but I couldn't quite figure it out.
